### PR TITLE
Coursesv1

### DIFF
--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -98,7 +98,7 @@ td {
 .modal {
     display: none; 
     position: fixed; 
-    z-index: 1; 
+    z-index: 1001; 
     padding-top: 100px; 
     left: 0;
     top: 0;

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -51,13 +51,12 @@ export default function Profile() {
     const history = useHistory();
 
     /* istanbul ignore next */
-    //consts here are for submission form to add courses to current users' document in Course collection.
-    const [loading, setLoading] = useState(false)
-    const courseNameRef = useRef();
-    const courseIDRef = useRef();
-    const examGRef = useRef();
-    const homeworkGRef = useRef();
-    const projectGRef = useRef();
+    const [loading, setLoading] = useState(false) /* istanbul ignore next */
+    const courseNameRef = useRef(); /* istanbul ignore next */
+    const courseIDRef = useRef(); /* istanbul ignore next */
+    const examGRef = useRef(); /* istanbul ignore next */
+    const homeworkGRef = useRef(); /* istanbul ignore next */
+    const projectGRef = useRef(); /* istanbul ignore next */
 
     /* istanbul ignore next */ 
     db.getCollection('Users').doc(currentUser.email).get().then((doc) => {
@@ -101,7 +100,6 @@ export default function Profile() {
         }).catch(error => console.log(error))
         }
         
-    
     useEffect(() =>{
         getData()
     },[])

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -85,6 +85,7 @@ export default function Profile() {
     const [tasks, setTasks] = useState([]) /* istanbul ignore next */
     const history = useHistory();
 
+    //consts here are for submission form to add courses to current users' document in Course collection.
     /* istanbul ignore next */
     const [loading, setLoading] = useState(false) /* istanbul ignore next */
     const courseNameRef = useRef(); /* istanbul ignore next */

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -58,7 +58,6 @@ export default function Profile() {
     const examGRef = useRef();
     const homeworkGRef = useRef();
     const projectGRef = useRef();
-    const courseList = [];
 
     /* istanbul ignore next */ 
     db.getCollection('Users').doc(currentUser.email).get().then((doc) => {
@@ -102,13 +101,6 @@ export default function Profile() {
         }).catch(error => console.log(error))
         }
         
-    function pushContent(){
-        courseList.push(courseNameRef)
-        courseList.push(courseIDRef)
-        courseList.push(examGRef)
-        courseList.push(homeworkGRef)
-        courseList.push(projectGRef)
-    }
     
     useEffect(() =>{
         getData()


### PR DESCRIPTION
I fixed the issue for the add-course modal on the live deployment site. The issue was that the z-indices for the modals were too low, hence why we could click on the logout button while the add-courses modal was up. With its new z-index, the only way to close the modal without adding a course is the x button. 